### PR TITLE
Update dbt.py with path param from dbt init

### DIFF
--- a/integration/common/openlineage/common/provider/dbt.py
+++ b/integration/common/openlineage/common/provider/dbt.py
@@ -672,7 +672,7 @@ class DbtArtifactProcessor:
         elif self.adapter_type == Adapter.REDSHIFT:
             return f"redshift://{profile['host']}:{profile['port']}"
         elif self.adapter_type == Adapter.DATABRICKS:
-            return f"databricks://{profile['host']}:{profile['port']}/?path={profile['endpoint_path']}"  
+            return f"databricks://{profile['host']}:{profile['port']}/?path={profile['http_path']}"  
         elif self.adapter_type == Adapter.SPARK:
             port = ""
 


### PR DESCRIPTION
The dbt-databricks profile is populated with an `http_path` param, and not an `endpoint_path` param

https://docs.getdbt.com/reference/warehouse-profiles/databricks-profile

